### PR TITLE
set node.js version used on travis to current LTS (node.js v12)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -70,6 +70,9 @@ matrix:
     - env: TOXENV=docs-links
 
 before_install:
+  - node --version
+  - npm --version
+  - nvm --version
   - ip addr show
   - printenv
   - npm i

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,9 @@ cache:
   - npm
   - docker
 
+node_js:
+  - 12
+
 services:
   - docker
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,6 @@ cache:
   - npm
   - docker
 
-node_js:
-  - 12
-
 services:
   - docker
 
@@ -70,6 +67,7 @@ matrix:
     - env: TOXENV=docs-links
 
 before_install:
+  - nvm install 12
   - node --version
   - npm --version
   - nvm --version


### PR DESCRIPTION
This prevents errors due to old node versions which aren't supported by some libraries.