### PR TITLE
Make tests fast fail

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -56,7 +56,6 @@ jobs:
     runs-on: ubuntu-latest
     needs: [flake8, docs]
     strategy:
-      fail-fast: false
       matrix:
         python-version: [3.6, 3.7]
         version_combinations:
@@ -133,7 +132,6 @@ jobs:
     runs-on: ubuntu-latest
     needs: [flake8, docs]
     strategy:
-      fail-fast: false
       matrix:
         version_combinations:
           [


### PR DESCRIPTION
Activated fast fail for tests, to save time when testing, since fails are mostly caused by racing conditions and not acctual problems.