### PR TITLE
Drop py27 support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -128,25 +128,21 @@ jobs:
           token: ${{secrets.CODECOV_TOKEN}}
           file: ./coverage.xml
 
-  test-py27-35:
+  test-py35:
     runs-on: ubuntu-latest
     needs: [flake8, docs]
     strategy:
       matrix:
         version_combinations:
           [
-            { "django": 1.11, "cms": 3.4, "python-version": 2.7 },
-            { "django": 1.11, "cms": 3.5, "python-version": 2.7 },
-            { "django": 1.11, "cms": 3.6, "python-version": 2.7 },
-            { "django": 1.11, "cms": 3.7, "python-version": 2.7 },
-            { "django": 1.11, "cms": 3.4, "python-version": 3.5 },
-            { "django": 1.11, "cms": 3.5, "python-version": 3.5 },
-            { "django": 1.11, "cms": 3.6, "python-version": 3.5 },
-            { "django": 1.11, "cms": 3.7, "python-version": 3.5 },
-            { "django": "2.0", "cms": 3.6, "python-version": 3.5 },
-            { "django": "2.0", "cms": 3.7, "python-version": 3.5 },
-            { "django": 2.1, "cms": 3.6, "python-version": 3.5 },
-            { "django": 2.1, "cms": 3.7, "python-version": 3.5 },
+            { "django": 1.11, "cms": 3.4 },
+            { "django": 1.11, "cms": 3.5 },
+            { "django": 1.11, "cms": 3.6 },
+            { "django": 1.11, "cms": 3.7 },
+            { "django": "2.0", "cms": 3.6 },
+            { "django": "2.0", "cms": 3.7 },
+            { "django": 2.1, "cms": 3.6 },
+            { "django": 2.1, "cms": 3.7 },
           ]
 
     steps:
@@ -164,10 +160,10 @@ jobs:
         run: |
           docker-compose up -d
           docker-compose ps
-      - name: Set up Python ${{ matrix.version_combinations.python-version }}
+      - name: Set up Python 3.5
         uses: actions/setup-python@v1
         with:
-          python-version: ${{ matrix.version_combinations.python-version }}
+          python-version: 3.5
 
       - name: Install dependencies
         run: |
@@ -201,7 +197,7 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
-    needs: [test-py36-37, test-py27-35]
+    needs: [test-py36-37, test-py35]
     steps:
       - uses: actions/checkout@v1
       - name: Setup Node.js

--- a/README.rst
+++ b/README.rst
@@ -15,13 +15,9 @@ djangocms-equation
         :target: https://djangocms-equation.readthedocs.io/en/latest/?badge=latest
         :alt: Documentation Status
 
-.. image:: https://pyup.io/repos/github/s-weigand/djangocms-equation/shield.svg
-        :target: https://pyup.io/repos/github/s-weigand/djangocms-equation/
-        :alt: Python Updates
-
-.. image:: https://badges.greenkeeper.io/s-weigand/djangocms-equation.svg
-        :target: https://greenkeeper.io/
-        :alt: Typescript/Javascript Updates
+.. image:: https://api.dependabot.com/badges/status?host=github&repo=s-weigand/djangocms-equation
+        :target: https://dependabot.com
+        :alt: Dependabot Status
 
 .. image:: https://codecov.io/gh/s-weigand/djangocms-equation/branch/master/graph/badge.svg
         :target: https://codecov.io/gh/s-weigand/djangocms-equation

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,11 @@ with open("README.rst") as readme_file:
 with open("HISTORY.rst") as history_file:
     history = history_file.read()
 
-requirements = ["django-cms>=3.4,<3.8", "django>=1.11,<3.0", "djangocms-text-ckeditor>=3.2.1"]
+requirements = [
+    "django-cms>=3.4,<3.8",
+    "django>=1.11,<3.0",
+    "djangocms-text-ckeditor>=3.2.1",
+]
 
 setup(
     author="Sebastian Weigand",
@@ -32,8 +36,6 @@ setup(
         "Topic :: Communications",
         "Topic :: Internet :: WWW/HTTP :: Dynamic Content",
         "Topic :: Internet :: WWW/HTTP :: Dynamic Content :: Message Boards",
-        "Programming Language :: Python :: 2",
-        "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
@@ -48,7 +50,7 @@ setup(
     keywords="djangocms-equation",
     name="djangocms-equation",
     packages=find_packages(include=["djangocms_equation"]),
-    python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*",
+    python_requires=">=3.5",
     test_suite="tests.settings.run",
     url="https://github.com/s-weigand/djangocms-equation",
     version="0.0.1",


### PR DESCRIPTION
Python 2.7 [is being deprecated ](https://www.python.org/dev/peps/pep-0373/), which is why this package will drop the support.