### PR TITLE
adapt to codecov action changes

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -173,6 +173,7 @@ jobs:
           pip install -U pip
           pip install -U -e .
           pip install -U -r requirements_dev.txt
+          pip install -U 'webdriver_manager==2.3.0'
           pip install 'django==${{ matrix.version_combinations.django }}.*' 'django-cms==${{ matrix.version_combinations.cms }}.*'
       - name: Show installed packages
         run: pip freeze

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,4 +1,4 @@
-name: 'Tests'
+name: "Tests"
 on: [push, pull_request]
 
 jobs:
@@ -61,15 +61,15 @@ jobs:
         python-version: [3.6, 3.7]
         version_combinations:
           [
-            { 'django': 1.11, 'cms': 3.4 },
-            { 'django': 1.11, 'cms': 3.5 },
-            { 'django': 1.11, 'cms': 3.6 },
-            { 'django': 1.11, 'cms': 3.7 },
-            { 'django': '2.0', 'cms': 3.6 },
-            { 'django': '2.0', 'cms': 3.7 },
-            { 'django': 2.1, 'cms': 3.7 },
-            { 'django': 2.1, 'cms': 3.6 },
-            { 'django': 2.2, 'cms': 3.7 },
+            { "django": 1.11, "cms": 3.4 },
+            { "django": 1.11, "cms": 3.5 },
+            { "django": 1.11, "cms": 3.6 },
+            { "django": 1.11, "cms": 3.7 },
+            { "django": "2.0", "cms": 3.6 },
+            { "django": "2.0", "cms": 3.7 },
+            { "django": 2.1, "cms": 3.7 },
+            { "django": 2.1, "cms": 3.6 },
+            { "django": 2.2, "cms": 3.7 },
           ]
 
     steps:
@@ -122,15 +122,13 @@ jobs:
         if: matrix.version_combinations.django == 2.1 && matrix.version_combinations.cms == 3.7 && matrix.python-version == 3.7 && (github.ref == 'refs/heads/master' || github.base_ref == 'master' )
         uses: percy/snapshot-action@v0.1.1
         with:
-          build-directory: 'test_screenshots'
+          build-directory: "test_screenshots"
           verbose: true
         env:
           PERCY_TOKEN: ${{ secrets.PERCY_TOKEN }}
       - name: Codecov Upload
-        continue-on-error: true
         uses: codecov/codecov-action@v1
         with:
-          token: ${{secrets.CODECOV_TOKEN}}
           file: ./coverage.xml
 
   test-py35:
@@ -140,14 +138,14 @@ jobs:
       matrix:
         version_combinations:
           [
-            { 'django': 1.11, 'cms': 3.4 },
-            { 'django': 1.11, 'cms': 3.5 },
-            { 'django': 1.11, 'cms': 3.6 },
-            { 'django': 1.11, 'cms': 3.7 },
-            { 'django': '2.0', 'cms': 3.6 },
-            { 'django': '2.0', 'cms': 3.7 },
-            { 'django': 2.1, 'cms': 3.6 },
-            { 'django': 2.1, 'cms': 3.7 },
+            { "django": 1.11, "cms": 3.4 },
+            { "django": 1.11, "cms": 3.5 },
+            { "django": 1.11, "cms": 3.6 },
+            { "django": 1.11, "cms": 3.7 },
+            { "django": "2.0", "cms": 3.6 },
+            { "django": "2.0", "cms": 3.7 },
+            { "django": 2.1, "cms": 3.6 },
+            { "django": 2.1, "cms": 3.7 },
           ]
 
     steps:
@@ -193,10 +191,8 @@ jobs:
           name: screenshots
           path: test_screenshots
       - name: Codecov Upload
-        continue-on-error: true
         uses: codecov/codecov-action@v1
         with:
-          token: ${{secrets.CODECOV_TOKEN}}
           file: ./coverage.xml
 
   deploy:

--- a/tox.ini
+++ b/tox.ini
@@ -24,7 +24,6 @@ commands =
 
 [testenv:flake8]
 basepython = python
-commands_pre = pip install flake8
 commands = flake8 djangocms_equation tests
 
 [testenv]
@@ -40,7 +39,9 @@ deps =
     cms35: django-cms>=3.5,<3.6
     cms36: django-cms>=3.6,<3.7
     cms37: django-cms>=3.7,<3.8
-commands_pre = {envpython} -m pip install -U -q -r {toxinidir}/requirements_dev.txt
+commands_pre =
+    {envpython} -m pip install -U -q -r {toxinidir}/requirements_dev.txt
+    py35: {envpython} -m pip install -U -q 'webdriver-manager==2.3.0'
 commands =
     {envpython} --version
     {env:COMMAND:coverage} erase


### PR DESCRIPTION
- `continue-on-error` was deprecated
- `token` isn't needed anymore for public repos and dropping it allows codcov upload from fork PRs