### PR TITLE
Revert "Update django-cms requirement from <3.8,>=3.4 to >=3.4,<3.9"

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ with open("HISTORY.md") as history_file:
     history = history_file.read()
 
 requirements = [
-    "django-cms>=3.4,<3.9",
+    "django-cms>=3.4,<3.8",
     "django>=1.11,!=2.0.*,<3.0",
     "djangocms-text-ckeditor>=3.2.1,<4.0.0",
 ]


### PR DESCRIPTION
Reverts s-weigand/djangocms-equation#130

This revert is for the `0.2.2` release, which will include #179 .

The `0.3.0` release will then add back the django-cms 3.8 support but drop support for EOL version django `1.11`, `2.1` and add support for django `3.1`. Support for django `3.0` won't be added since it is [nearly EOL](https://endoflife.date/django).
Dropping the support for older django versions will also result in dropping support for django-cms < `3.7`