### PR TITLE
🚇 Optimize CI

### DIFF
--- a/.github/workflows/autoupdate-pre-commit-config.yml
+++ b/.github/workflows/autoupdate-pre-commit-config.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v3
       - uses: actions/cache@v2
         with:
           path: ~/.cache/pre-commit

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,5 +1,11 @@
 name: 'Tests'
-on: [push, pull_request]
+on:
+  push:
+    tags:
+      - v**
+    branches-ignore:
+      - 'dependabot/**'
+  pull_request:
 
 jobs:
   misspell:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Check out repo
         uses: actions/checkout@v3
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v3
       - name: Run pre-commit
         uses: pre-commit/action@v2.0.3
 
@@ -40,7 +40,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python 3.7
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v3
         with:
           python-version: 3.7
       - name: Install dependencies
@@ -58,7 +58,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python 3.7
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v3
         with:
           python-version: 3.7
       - name: Install dependencies
@@ -105,7 +105,7 @@ jobs:
           docker-compose up -d
           docker-compose ps
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v3
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -173,7 +173,7 @@ jobs:
           npm ci
           npm run publish
       - name: Set up Python 3.7
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v3
         with:
           python-version: 3.7
       - name: Install dependencies

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ jobs:
     name: Check spelling
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: misspell
         uses: reviewdog/action-misspell@v1
         with:
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Set up Python
         uses: actions/setup-python@v2
       - name: Run pre-commit
@@ -38,7 +38,7 @@ jobs:
     name: Build docs
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Python 3.7
         uses: actions/setup-python@v2
         with:
@@ -56,7 +56,7 @@ jobs:
     name: Check Links in docs
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Python 3.7
         uses: actions/setup-python@v2
         with:
@@ -90,7 +90,7 @@ jobs:
           ]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Setup Node.js
         uses: actions/setup-node@v2
@@ -163,7 +163,7 @@ jobs:
     if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
     needs: [tests]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Setup Node.js
         uses: actions/setup-node@v2
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -77,7 +77,7 @@ jobs:
     needs: [pre-commit, docs]
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9]
         version_combinations:
           [
             { 'django': 1.11, 'cms': 3.4 },

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,6 +5,7 @@ on:
       - v**
     branches-ignore:
       - 'dependabot/**'
+      - 'create-pr-action/**'
   pull_request:
 
 jobs:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -93,7 +93,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Setup Node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: 14.x
       - name: Compile assets
@@ -165,7 +165,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Setup Node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: 14.x
       - name: Compile assets

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -107,7 +107,7 @@ Before you submit a pull request, check that it meets these guidelines:
 2. If the pull request adds functionality, the docs should be updated. Put
    your new functionality into a function with a docstring, and add the
    feature to the list in README.rst.
-3. The pull request should work for Python 3.5, 3.6 and 3.7. Check
+3. The pull request should work for Python 3.7, 3.8 and 3.9. Check
    https://github.com/s-weigand/djangocms-equation/actions
    and make sure that the tests pass for all supported Python versions.
 

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,6 @@ setup(
         "Topic :: Internet :: WWW/HTTP :: Dynamic Content",
         "Topic :: Internet :: WWW/HTTP :: Dynamic Content :: Message Boards",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
@@ -54,7 +53,7 @@ setup(
     keywords="djangocms-equation django-cms django cms equation latex katex mhchem",
     name="djangocms-equation",
     packages=find_packages(include=["djangocms_equation"]),
-    python_requires=">=3.6",
+    python_requires=">=3.7",
     test_suite="tests.settings.run",
     url="https://github.com/s-weigand/djangocms-equation",
     project_urls={

--- a/tox.ini
+++ b/tox.ini
@@ -5,9 +5,9 @@ envlist =
     pre-commit
     docs-create
     docs-links
-    py{36,37,38,39}-dj111-cms{34,35,36,37}
-    py{36,37,38,39}-dj{21}-cms{36,37}
-    py{36,37,38,39}-dj22-cms37
+    py{37,38,39}-dj111-cms{34,35,36,37}
+    py{37,38,39}-dj{21}-cms{36,37}
+    py{37,38,39}-dj22-cms37
 
 
 [flake8]


### PR DESCRIPTION
Remove bot branches from running on push so they don't run twice.

**Changes:**
- [🚇 Exclude dependabot branches from runs on push](https://github.com/s-weigand/djangocms-equation/commit/13a62a7c6562fa1a292b16261501e6d1642ed325)
- [🚇 Exclude create-pr-action branches from runs on push](https://github.com/s-weigand/djangocms-equation/commit/80ccec3cba50e9b51c8d546f64bd337a67f1e235)